### PR TITLE
Deduplicate columns in-place

### DIFF
--- a/src/fuzzymatch_records/deduplicate.py
+++ b/src/fuzzymatch_records/deduplicate.py
@@ -18,8 +18,8 @@ from fuzzymatch_records.clean_columns import clean_fuzzy_columns
 def deduplicate_dataframe_columns(
     df: pd.DataFrame, columns: List[str], min_similarities: List[float],
 ) -> pd.DataFrame:
-    """Deduplicates columns for according to the min_similarity specified for 
-    each column.
+    """Deduplicates columns in-place for according to the min_similarity 
+    specified for each column.
 
     Example
     -------
@@ -44,8 +44,6 @@ def deduplicate_dataframe_columns(
 
     for column, min_similarity in zip(columns, min_similarities):
 
-        df[column + "_deduplicated"] = group_similar_strings(
-            df[column], min_similarity=min_similarity
-        )
+        df[column] = group_similar_strings(df[column], min_similarity=min_similarity)
 
     return df

--- a/src/fuzzymatch_records/parse_addresses.py
+++ b/src/fuzzymatch_records/parse_addresses.py
@@ -7,36 +7,6 @@ from IPython.core.debugger import set_trace
 def _extract_dublin_postcodes(series: pd.Series) -> pd.Series:
 
     return series.str.extract(pat=r"(dublin \d+\w?)", flags=IGNORECASE)[0]
-<<<<<<< HEAD
-
-
-def extract_dublin_postcodes(
-    df: pd.DataFrame, address_column: str, postcode_column: str = "extracted_postcodes",
-) -> pd.DataFrame:
-    """Extracts numeric county names (Dublin 1, Dublin 2 etc) from the
-    specified address column.  Won't extract Dublin County addresses
-
-    Parameters
-    ----------
-    df : pd.DataFrame
-    address_column : str
-        Name of address column
-    postcode_column: str, optional
-        Name of new postcode column, by default "extracted_postcodes" 
-
-    Returns
-    -------
-    pd.DataFrame
-    """
-    return df.assign(
-        **{postcode_column: df[address_column].pipe(_extract_dublin_postcodes)}
-    )
-
-
-def _remove_dublin_postcodes(series: pd.Series) -> pd.Series:
-
-    return series.str.replace(pat=r"(dublin \d+\w?)", repl="", flags=IGNORECASE)
-=======
 
 
 def extract_dublin_postcodes(df: pd.DataFrame, column: str) -> pd.DataFrame:
@@ -54,21 +24,12 @@ def extract_dublin_postcodes(df: pd.DataFrame, column: str) -> pd.DataFrame:
     pd.DataFrame
     """
     return df.assign(extracted_postcodes=df[column].pipe(_extract_dublin_postcodes))
->>>>>>> fde24b279ac88119a9810e18cd861a74d8e45a90
 
 
 def remove_dublin_postcodes(df: pd.DataFrame, address_column: str) -> pd.DataFrame:
     """Removes Dublin postcodes in-place from specified address column
 
-<<<<<<< HEAD
-    Parameters
-    ----------
-    df : pd.DataFrame
-    address_column : str
-        Name of address column in dataframe
-=======
     return series.str.replace(pat=r"(dublin \d+\w?)", repl="", flags=IGNORECASE)
->>>>>>> fde24b279ac88119a9810e18cd861a74d8e45a90
 
     Returns
     -------
@@ -91,20 +52,6 @@ def _extract_address_numbers(series: pd.Series) -> pd.Series:
     import ipdb
 
     ipdb.set_trace()
-<<<<<<< HEAD
-=======
-
-    pattern = """
-    (
-        \w*         # (optional) Starts with letters (ex: M4)
-        \d+         # All numeric characters 
-        [/-]?       # (optional) '-' or '/' (ex: 19/...)
-        \d*         # (optional) second group of numbers (ex: 19/20)
-        \w*         # (optional) Ends with letters (1st)
-    )"""
-
-    return series.str.extract(pat=pattern, flags=IGNORECASE | VERBOSE)[0]
->>>>>>> fde24b279ac88119a9810e18cd861a74d8e45a90
 
     pattern = """
     (


### PR DESCRIPTION
Minimises clutter resulting from renaming column
side-effect.  If want to keep the original columns
can save them before applying this function