### PR TITLE
Keep dash and slash

### DIFF
--- a/src/fuzzymatch_records/clean_columns.py
+++ b/src/fuzzymatch_records/clean_columns.py
@@ -15,7 +15,7 @@ def clean_fuzzy_column(series: pd.Series) -> pd.Series:
         .apply(fix_text)
         .apply(unidecode)
         .str.replace("&", "and")
-        .str.replace(r"[,-./]|\sBD", " ")
+        .str.replace(r"[,.]|\sBD", " ")
         .str.replace("  ", " ")
         .str.title()
         .str.pad(width=1, side="both", fillchar=" ")


### PR DESCRIPTION
Previously, addresses post-cleaning incorrectly lose dash and slash so '18/19 x road' makes no sense